### PR TITLE
Add `vue-scoped-css/require-v-slotted-argument` rule

### DIFF
--- a/.github/workflows/NpmPublish.yml
+++ b/.github/workflows/NpmPublish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: setup Node
       uses: actions/setup-node@v1
       with:

--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ Enforce all the rules in this category with:
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
-| [vue-scoped-css/no-deprecated-deep-combinator](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/no-deprecated-deep-combinator.html) | disallow using deprecated deep combinators |  |
+| [vue-scoped-css/no-deprecated-deep-combinator](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/no-deprecated-deep-combinator.html) | disallow using deprecated deep combinators | :wrench: |
 | [vue-scoped-css/no-parsing-error](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/no-parsing-error.html) | Disallow parsing errors in `<style>` |  |
 | [vue-scoped-css/no-unused-keyframes](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/no-unused-keyframes.html) | Reports the `@keyframes` is not used in Scoped CSS. |  |
 | [vue-scoped-css/no-unused-selector](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/no-unused-selector.html) | Reports selectors defined in Scoped CSS not used in `<template>`. |  |
 | [vue-scoped-css/require-scoped](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/require-scoped.html) | Enforce the `<style>` tags to has the `scoped` attribute. |  |
 | [vue-scoped-css/require-v-deep-argument](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/require-v-deep-argument.html) | require selector argument to be passed to `::v-deep()`. | :wrench: |
+| [vue-scoped-css/require-v-slotted-argument](https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/require-v-slotted-argument.html) | require selector argument to be passed to `::v-slotted()`. |  |
 
 ## Recommended for Vue.js 2.x
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -18,12 +18,13 @@ Enforce all the rules in this category with:
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
-| [vue-scoped-css/no-deprecated-deep-combinator](./no-deprecated-deep-combinator.md) | disallow using deprecated deep combinators |  |
+| [vue-scoped-css/no-deprecated-deep-combinator](./no-deprecated-deep-combinator.md) | disallow using deprecated deep combinators | :wrench: |
 | [vue-scoped-css/no-parsing-error](./no-parsing-error.md) | Disallow parsing errors in `<style>` |  |
 | [vue-scoped-css/no-unused-keyframes](./no-unused-keyframes.md) | Reports the `@keyframes` is not used in Scoped CSS. |  |
 | [vue-scoped-css/no-unused-selector](./no-unused-selector.md) | Reports selectors defined in Scoped CSS not used in `<template>`. |  |
 | [vue-scoped-css/require-scoped](./require-scoped.md) | Enforce the `<style>` tags to has the `scoped` attribute. |  |
 | [vue-scoped-css/require-v-deep-argument](./require-v-deep-argument.md) | require selector argument to be passed to `::v-deep()`. | :wrench: |
+| [vue-scoped-css/require-v-slotted-argument](./require-v-slotted-argument.md) | require selector argument to be passed to `::v-slotted()`. |  |
 
 ## Recommended for Vue.js 2.x
 

--- a/docs/rules/no-deprecated-deep-combinator.md
+++ b/docs/rules/no-deprecated-deep-combinator.md
@@ -9,12 +9,13 @@ description: "disallow using deprecated deep combinators"
 > disallow using deprecated deep combinators
 
 - :gear: This rule is included in `"plugin:vue-scoped-css/vue3-recommended"` and `"plugin:vue-scoped-css/all"`.
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details
 
 This rule reports the use of deprecated deep combinators as errors.
 
-<eslint-code-block :rules="{'vue-scoped-css/no-deprecated-deep-combinator': ['error']}">
+<eslint-code-block fix :rules="{'vue-scoped-css/no-deprecated-deep-combinator': ['error']}">
 
 ```vue
 <style scoped>

--- a/docs/rules/require-v-deep-argument.md
+++ b/docs/rules/require-v-deep-argument.md
@@ -21,7 +21,7 @@ This rule reports `::v-deep` pseudo-element with no selector argument passed.
 <style scoped>
 /* ✗ BAD */
 .baz .qux ::v-deep .foo .bar {}
-.baz .qux ::v-deep() .foo .bar {}
+.baz .qux ::v-deep() {}
 
 /* ✓ GOOD */
 .baz .qux ::v-deep(.foo .bar) {}

--- a/docs/rules/require-v-slotted-argument.md
+++ b/docs/rules/require-v-slotted-argument.md
@@ -1,0 +1,39 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "vue-scoped-css/require-v-slotted-argument"
+description: "require selector argument to be passed to `::v-slotted()`."
+---
+# vue-scoped-css/require-v-slotted-argument
+
+> require selector argument to be passed to `::v-slotted()`.
+
+- :gear: This rule is included in `"plugin:vue-scoped-css/vue3-recommended"` and `"plugin:vue-scoped-css/all"`.
+
+## :book: Rule Details
+
+This rule reports `::v-slotted` pseudo-element with no selector argument passed.
+
+<eslint-code-block :rules="{'vue-scoped-css/require-v-slotted-argument': ['error']}">
+
+```vue
+<style scoped>
+/* ✗ BAD */
+.baz .qux ::v-slotted() {}
+.baz .qux ::v-slotted {}
+
+/* ✓ GOOD */
+.baz .qux ::v-slotted(.foo .bar) {}
+</style>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## Implementation
+
+- [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/require-v-slotted-argument.ts)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-slotted-argument.js)

--- a/lib/rules/require-v-slotted-argument.ts
+++ b/lib/rules/require-v-slotted-argument.ts
@@ -1,0 +1,81 @@
+import {
+    getStyleContexts,
+    getCommentDirectivesReporter,
+    StyleContext,
+    ValidStyleContext,
+} from "../styles/context"
+import type { RuleContext, Rule } from "../types"
+import {
+    isPseudoEmptyArguments,
+    isVSlottedPseudo,
+    VSlottedPseudo,
+} from "../styles/utils/selectors"
+
+declare const module: {
+    exports: Rule
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "require selector argument to be passed to `::v-slotted()`.",
+            categories: ["vue3-recommended"],
+            default: "warn",
+            url:
+                "https://future-architect.github.io/eslint-plugin-vue-scoped-css/rules/require-v-slotted-argument.html",
+        },
+        fixable: null,
+        messages: {
+            missingArguments:
+                "Need to pass argument to the `::v-slotted` pseudo-element.",
+        },
+        schema: [],
+        type: "suggestion", // "problem",
+    },
+    create(context: RuleContext) {
+        const styles = getStyleContexts(context)
+            .filter(StyleContext.isValid)
+            .filter((style) => style.scoped)
+        if (!styles.length) {
+            return {}
+        }
+        const reporter = getCommentDirectivesReporter(context)
+
+        /**
+         * Reports the given node
+         * @param {ASTNode} node node to report
+         */
+        function report(node: VSlottedPseudo) {
+            reporter.report({
+                node,
+                loc: node.loc,
+                messageId: "missingArguments",
+            })
+        }
+
+        /**
+         * Verify the style
+         */
+        function verify(style: ValidStyleContext) {
+            style.traverseSelectorNodes({
+                enterNode(node) {
+                    if (
+                        isVSlottedPseudo(node) &&
+                        isPseudoEmptyArguments(node)
+                    ) {
+                        report(node)
+                    }
+                },
+            })
+        }
+
+        return {
+            "Program:exit"() {
+                for (const style of styles) {
+                    verify(style)
+                }
+            },
+        }
+    },
+}

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -36,6 +36,11 @@ const baseRules = [
         ruleName: "require-v-deep-argument",
         ruleId: "vue-scoped-css/require-v-deep-argument",
     },
+    {
+        rule: require("../rules/require-v-slotted-argument"),
+        ruleName: "require-v-slotted-argument",
+        ruleId: "vue-scoped-css/require-v-slotted-argument",
+    },
 ]
 
 export const rules = baseRules.map((obj) => {

--- a/tests/lib/rules/require-v-slotted-argument.ts
+++ b/tests/lib/rules/require-v-slotted-argument.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from "eslint"
+const rule = require("../../../lib/rules/require-v-slotted-argument")
+
+const tester = new RuleTester({
+    parser: require.resolve("vue-eslint-parser"),
+    parserOptions: {
+        ecmaVersion: 2019,
+        sourceType: "module",
+    },
+})
+
+tester.run("require-v-slotted-argument", rule, {
+    valid: [
+        `
+        <template><div class="item">sample</div></template>
+        <style scoped>
+        .baz .qux ::v-slotted(.foo .bar) {}
+        </style>
+        `,
+    ],
+    invalid: [
+        {
+            code: `
+            <template><div class="item">sample</div></template>
+            <style scoped>
+            .baz .qux ::v-slotted .foo .bar {}
+            .baz .qux ::v-slotted() {}
+            </style>
+            `,
+            errors: [
+                {
+                    message:
+                        "Need to pass argument to the `::v-slotted` pseudo-element.",
+                    line: 4,
+                    column: 23,
+                    endLine: 4,
+                    endColumn: 34,
+                },
+                {
+                    message:
+                        "Need to pass argument to the `::v-slotted` pseudo-element.",
+                    line: 5,
+                    column: 23,
+                    endLine: 5,
+                    endColumn: 36,
+                },
+            ],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds `vue-scoped-css/require-v-slotted-argument` rule.

`vue-scoped-css/require-v-slotted-argument` rule reports `::v-slotted` pseudo-element with no selector argument passed.