### PR TITLE
fix(enforce-style-type): correct  typos

### DIFF
--- a/lib/rules/enforce-style-type.ts
+++ b/lib/rules/enforce-style-type.ts
@@ -35,7 +35,7 @@ module.exports = {
             change:
                 "Change `{{ fromAttribute }}` to `{{ toAttribute }}` attribute.",
             forbiddenStyle: "`{{ attribute }}` attribute is forbidden.",
-            forbiddenPlain: "Missing atributes {{ attributes }}.",
+            forbiddenPlain: "Missing attributes {{ attributes }}.",
             forbiddenScopedModule:
                 "Cannot use both `scoped` and `module` attributes.",
         },

--- a/lib/rules/enforce-style-type.ts
+++ b/lib/rules/enforce-style-type.ts
@@ -153,7 +153,7 @@ module.exports = {
                 data: {
                     attributes: allows
                         .map((allow) => `\`${allow}\``)
-                        .join(", "),
+                        .join(" or "),
                 },
                 suggest: singleAllow
                     ? [

--- a/lib/rules/enforce-style-type.ts
+++ b/lib/rules/enforce-style-type.ts
@@ -35,7 +35,7 @@ module.exports = {
             change:
                 "Change `{{ fromAttribute }}` to `{{ toAttribute }}` attribute.",
             forbiddenStyle: "`{{ attribute }}` attribute is forbidden.",
-            forbiddenPlain: "Missing attributes {{ attributes }}.",
+            forbiddenPlain: "Missing attribute {{ attributes }}.",
             forbiddenScopedModule:
                 "Cannot use both `scoped` and `module` attributes.",
         },

--- a/lib/rules/enforce-style-type.ts
+++ b/lib/rules/enforce-style-type.ts
@@ -151,7 +151,9 @@ module.exports = {
                 node: node.startTag,
                 messageId: "forbiddenPlain",
                 data: {
-                    attributes: allows.map((allow) => `\`${allow}\``).join(", "),
+                    attributes: allows
+                        .map((allow) => `\`${allow}\``)
+                        .join(", "),
                 },
                 suggest: singleAllow
                     ? [

--- a/lib/rules/enforce-style-type.ts
+++ b/lib/rules/enforce-style-type.ts
@@ -151,7 +151,7 @@ module.exports = {
                 node: node.startTag,
                 messageId: "forbiddenPlain",
                 data: {
-                    attribute: allows.map((allow) => `\`${allow}\``).join(", "),
+                    attributes: allows.map((allow) => `\`${allow}\``).join(", "),
                 },
                 suggest: singleAllow
                     ? [


### PR DESCRIPTION
## Problem

Just tried out 1.2.0 and found that the error message was appearing as:
```
Missing atributes {{ attributes }}.
```
- `attributes` misspelt
- `{{ attributes }}` wasn't being passed in


## Changes
- Fixed typos
- Changed `, ` -> ` or ` and `attributes` -> `attribute`
  - Previously: ``464:1  error  Missing atributes `scoped`, `module`  vue-scoped-css/enforce-style-type``
  - Now: ``464:1  error  Missing attribute `scoped` or `module`  vue-scoped-css/enforce-style-type``