### PR TITLE
fix: change eslint peer dependencies to min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "postcss-styl": "^0.8.0"
     },
     "peerDependencies": {
-        "eslint": ">=7.30.0",
+        "eslint": ">=6.0.0",
         "vue-eslint-parser": ">=7.1.0"
     },
     "nyc": {

--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
         "postcss-styl": "^0.8.0"
     },
     "peerDependencies": {
-        "eslint": "7.30.0",
-        "vue-eslint-parser": "^7.1.0"
+        "eslint": ">=7.30.0",
+        "vue-eslint-parser": ">=7.1.0"
     },
     "nyc": {
         "include": [


### PR DESCRIPTION
Otherwise this causes issues in a monorepo as the installed version of eslint is split up in seperate node_modules