### PR TITLE
perf: 72 times faster to check `no-unused-selector`

### DIFF
--- a/.changeset/warm-cooks-shake.md
+++ b/.changeset/warm-cooks-shake.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue-scoped-css": patch
+---
+
+Improve `no-unused-selector` performance


### PR DESCRIPTION
Thank you for maintaining this ESLint plugin!
This plugin has helped improve the quality of my company's Vue3 code.

Today, I would like to improve one small thing.
Regarding my big Vue component, `no-unused-selector` takes `479.354 ms`.
But after this PR, it will be `6.662 ms`.

In this PR, just I applied a cache mechanism to avoid custom traverse　execution.
It may have a chance to use old code, but the cache duration is only 1 second.
So, personally, performance improvement has more benefits than this.

