### PR TITLE
The link to the test file was broken

### DIFF
--- a/docs/rules/enforce-style-type.md
+++ b/docs/rules/enforce-style-type.md
@@ -108,4 +108,4 @@ Only allow plain styles; no `scoped` or `module` attributes.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/enforce-style-type.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/enforce-style-type.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/enforce-style-type.ts)

--- a/docs/rules/no-deprecated-deep-combinator.md
+++ b/docs/rules/no-deprecated-deep-combinator.md
@@ -38,4 +38,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/no-deprecated-deep-combinator.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-deprecated-deep-combinator.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-deprecated-deep-combinator.ts)

--- a/docs/rules/no-deprecated-v-enter-v-leave-class.md
+++ b/docs/rules/no-deprecated-v-enter-v-leave-class.md
@@ -108,4 +108,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/no-deprecated-v-enter-v-leave-class.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-deprecated-v-enter-v-leave-class.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-deprecated-v-enter-v-leave-class.ts)

--- a/docs/rules/no-parent-of-v-global.md
+++ b/docs/rules/no-parent-of-v-global.md
@@ -35,4 +35,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/no-parent-of-v-global.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-parent-of-v-global.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-parent-of-v-global.ts)

--- a/docs/rules/no-parsing-error.md
+++ b/docs/rules/no-parsing-error.md
@@ -32,4 +32,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/no-parsing-error.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-parsing-error.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-parsing-error.ts)

--- a/docs/rules/no-unused-keyframes.md
+++ b/docs/rules/no-unused-keyframes.md
@@ -49,4 +49,4 @@ This rule reports `@keyframes` is not used in Scoped CSS.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/no-unused-keyframes.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-unused-keyframes.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-unused-keyframes.ts)

--- a/docs/rules/no-unused-selector.md
+++ b/docs/rules/no-unused-selector.md
@@ -162,4 +162,4 @@ a.button.star {
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/no-unused-selector.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-unused-selector.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-unused-selector.ts)

--- a/docs/rules/require-scoped.md
+++ b/docs/rules/require-scoped.md
@@ -72,4 +72,4 @@ Default is set to `always`.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/require-scoped.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-scoped.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-scoped.ts)

--- a/docs/rules/require-selector-used-inside.md
+++ b/docs/rules/require-selector-used-inside.md
@@ -127,4 +127,4 @@ a.button.star {
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/require-selector-used-inside.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-selector-used-inside.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-selector-used-inside.ts)

--- a/docs/rules/require-v-deep-argument.md
+++ b/docs/rules/require-v-deep-argument.md
@@ -37,4 +37,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/require-v-deep-argument.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-deep-argument.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-deep-argument.ts)

--- a/docs/rules/require-v-global-argument.md
+++ b/docs/rules/require-v-global-argument.md
@@ -36,4 +36,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/require-v-global-argument.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-global-argument.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-global-argument.ts)

--- a/docs/rules/require-v-slotted-argument.md
+++ b/docs/rules/require-v-slotted-argument.md
@@ -36,4 +36,4 @@ Nothing.
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/require-v-slotted-argument.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-slotted-argument.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-slotted-argument.ts)

--- a/docs/rules/v-deep-pseudo-style.md
+++ b/docs/rules/v-deep-pseudo-style.md
@@ -50,4 +50,4 @@ This rule enforces deep pseudo style which you should use `:deep()` or `::v-deep
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/v-deep-pseudo-style.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-deep-pseudo-style.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-deep-pseudo-style.ts)

--- a/docs/rules/v-global-pseudo-style.md
+++ b/docs/rules/v-global-pseudo-style.md
@@ -50,4 +50,4 @@ This rule enforces global pseudo style which you should use `:global()` or `::v-
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/v-global-pseudo-style.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-global-pseudo-style.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-global-pseudo-style.ts)

--- a/docs/rules/v-slotted-pseudo-style.md
+++ b/docs/rules/v-slotted-pseudo-style.md
@@ -50,4 +50,4 @@ This rule enforces slotted pseudo style which you should use `:slotted()` or `::
 ## Implementation
 
 - [Rule source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/lib/rules/v-slotted-pseudo-style.ts)
-- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-slotted-pseudo-style.js)
+- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-slotted-pseudo-style.ts)


### PR DESCRIPTION
The extension of the test file is .ts, but the documentation states a .js extension, which prevents navigation to the test file.

As a result, clicking on the TestSource in the image below does not lead to the test file.

![image](https://github.com/user-attachments/assets/3f99a651-a8e8-4904-9fab-b4ce93665f73)

In this PR, I have changed the extension of the test file mentioned in the documentation to .ts.


before the fix

```
$ cd ~/ghq/github.com/Issei0804-ie/eslint-plugin-vue-scoped-css
$ find ./docs/rules -type f -print | xargs grep '\[Test source\].*\.js'
./docs/rules/v-slotted-pseudo-style.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-slotted-pseudo-style.js)
./docs/rules/require-v-slotted-argument.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-slotted-argument.js)
./docs/rules/require-v-global-argument.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-global-argument.js)
./docs/rules/no-deprecated-v-enter-v-leave-class.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-deprecated-v-enter-v-leave-class.js)
./docs/rules/no-unused-keyframes.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-unused-keyframes.js)
./docs/rules/v-global-pseudo-style.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-global-pseudo-style.js)
./docs/rules/no-parsing-error.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-parsing-error.js)
./docs/rules/require-selector-used-inside.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-selector-used-inside.js)
./docs/rules/enforce-style-type.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/enforce-style-type.js)
./docs/rules/no-deprecated-deep-combinator.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-deprecated-deep-combinator.js)
./docs/rules/v-deep-pseudo-style.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/v-deep-pseudo-style.js)
./docs/rules/require-scoped.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-scoped.js)
./docs/rules/require-v-deep-argument.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/require-v-deep-argument.js)
./docs/rules/no-unused-selector.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-unused-selector.js)
./docs/rules/no-parent-of-v-global.md:- [Test source](https://github.com/future-architect/eslint-plugin-vue-scoped-css/blob/master/tests/lib/rules/no-parent-of-v-global.js)
```


After the fix

```
$ cd ~/ghq/github.com/Issei0804-ie/eslint-plugin-vue-scoped-css
$ find ./docs/rules -type f -print | xargs grep '\[Test source\].*\.js'
# no output
```


