### PR TITLE
feat(TS): add types so that rules can be used in TS eslint.config files

### DIFF
--- a/.changeset/afraid-apples-hunt.md
+++ b/.changeset/afraid-apples-hunt.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue-scoped-css": minor
+---
+
+feat(TS): add types so that rules can be used in TS eslint.config files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # eslint-plugin-vue-scoped-css
 
+## 2.9.01
+
+### Minor Changes
+
+- feat: Add TS declarations to bundle ([#394](https://github.com/future-architect/eslint-plugin-vue-scoped-css/pull/394))
+
 ## 2.9.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # eslint-plugin-vue-scoped-css
 
-## 2.9.01
-
-### Minor Changes
-
-- feat: Add TS declarations to bundle ([#394](https://github.com/future-architect/eslint-plugin-vue-scoped-css/pull/394))
-
 ## 2.9.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vue-scoped-css",
-  "version": "2.9.1",
+  "version": "2.9.0",
   "description": "ESLint plugin for Scoped CSS in Vue.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "eslint-plugin-vue-scoped-css",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "ESLint plugin for Scoped CSS in Vue.js",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "npm run -s clean",
     "build": "tsc --project ./tsconfig.build.json",
@@ -49,7 +50,8 @@
     "css"
   ],
   "files": [
-    "dist"
+    "dist",
+    "dist/index.d.ts"
   ],
   "devDependencies": {
     "@changesets/cli": "^2.27.5",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["tests/**/*", "tools/**/*"],
   "compilerOptions": {
-    "removeComments": true /* Do not emit comments to output. */
+    "removeComments": true, /* Do not emit comments to output. */
+    "declaration": true
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["tests/**/*", "tools/**/*"],
   "compilerOptions": {
-    "removeComments": true, /* Do not emit comments to output. */
+    "removeComments": true /* Do not emit comments to output. */,
     "declaration": true
   }
 }


### PR DESCRIPTION
We would like to use the plugin to eslint our vue files, but as we are in full TS environment, our eslint.config.ts file need typings for all plugins and this is preventing us to use it.

The project is already using Typescript even for building, it's a pity that type definitions are not published. 

Can it be enhanced with these changes, so that types can be available?

I've tested the builded package and it is working fine with our TS configurations, another look at it would be nice.
![image](https://github.com/user-attachments/assets/4c26a3f9-4f9b-45ca-aaf3-0e75a42bb8a0)


Thanks in advance.