### PR TITLE
Add extraClassAttributes option to match additional class-like attributes in templates

### DIFF
--- a/.changeset/afraid-bikes-smile.md
+++ b/.changeset/afraid-bikes-smile.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue-scoped-css": minor
+---
+
+Add `extraClassAttributes` option to match additional class-like attributes in templates, to `vue-scoped-css/no-unused-selector` rule

--- a/docs/rules/no-unused-selector.md
+++ b/docs/rules/no-unused-selector.md
@@ -91,6 +91,7 @@ This is a limitation of this rule. Without this limitation, the root element can
     "ignoreBEMModifier": false,
     "captureClassesFromDoc": [],
     "checkUnscoped": false,
+    "customClassAttributes": [],
   }]
 }
 ```
@@ -98,6 +99,7 @@ This is a limitation of this rule. Without this limitation, the root element can
 - `ignoreBEMModifier` ... Set `true` if you want to ignore the `BEM` modifier. Default is false.
 - `captureClassesFromDoc` ... Specifies the regexp that extracts the class name from the documentation in the comments. Even if there is no matching element, no error is reported if the document of a class name exists in the comments.
 - `checkUnscoped` ... The rule only checks `<style scoped>` by default, but if set to `true` it will also check `<style>` without the scoped attribute. If you set it to `true`, be very careful that the warned CSS may actually be used outside the `.vue` file.
+- `customClassAttributes` ... Specifies an array of custom attribute names to check for class names in addition to the standard `class` attribute. Useful for frameworks that use custom attributes like `hover-class`, `placeholder-class`, etc. Default is an empty array.
 
 ### `"ignoreBEMModifier": true`
 
@@ -148,6 +150,42 @@ a.button.star {
 ```
 
 </eslint-code-block>
+
+### `"customClassAttributes": ["hover-class", "placeholder-class"]`
+
+<eslint-code-block :rules="{'vue-scoped-css/no-unused-selector': ['error', {customClassAttributes: ['hover-class', 'placeholder-class']}]}">
+
+```vue
+<template>
+  <div>
+    <!-- These attributes will be checked for class names -->
+    <button hover-class="button-hover" placeholder-class="button-placeholder">Button</button>
+    <input
+      :hover-class="dynamicHoverClass"
+      :placeholder-class="['input-placeholder', 'input-focus']"
+    />
+  </div>
+</template>
+<style scoped>
+/* ✓ GOOD - These selectors are used in custom attributes */
+.button-hover {}
+.button-placeholder {}
+.input-placeholder {}
+.input-focus {}
+
+/* ✗ BAD - This selector is not used anywhere */
+.unused-class {}
+</style>
+<script>
+export default {
+  data() {
+    return {
+      dynamicHoverClass: 'button-hover',
+    }
+  },
+}
+</script>
+```
 
 ## :books: Further reading
 

--- a/docs/rules/no-unused-selector.md
+++ b/docs/rules/no-unused-selector.md
@@ -91,7 +91,7 @@ This is a limitation of this rule. Without this limitation, the root element can
     "ignoreBEMModifier": false,
     "captureClassesFromDoc": [],
     "checkUnscoped": false,
-    "customClassAttributes": [],
+    "extraClassAttributes": [],
   }]
 }
 ```
@@ -99,7 +99,7 @@ This is a limitation of this rule. Without this limitation, the root element can
 - `ignoreBEMModifier` ... Set `true` if you want to ignore the `BEM` modifier. Default is false.
 - `captureClassesFromDoc` ... Specifies the regexp that extracts the class name from the documentation in the comments. Even if there is no matching element, no error is reported if the document of a class name exists in the comments.
 - `checkUnscoped` ... The rule only checks `<style scoped>` by default, but if set to `true` it will also check `<style>` without the scoped attribute. If you set it to `true`, be very careful that the warned CSS may actually be used outside the `.vue` file.
-- `customClassAttributes` ... Specifies an array of custom attribute names to check for class names in addition to the standard `class` attribute. Useful for frameworks that use custom attributes like `hover-class`, `placeholder-class`, etc. Default is an empty array.
+- `extraClassAttributes` ... Specifies an array of custom attribute names to check for class names in addition to the standard `class` attribute. Useful for frameworks that use custom attributes like `hover-class`, `placeholder-class`, etc. Default is an empty array.
 
 ### `"ignoreBEMModifier": true`
 
@@ -151,27 +151,23 @@ a.button.star {
 
 </eslint-code-block>
 
-### `"customClassAttributes": ["hover-class", "placeholder-class"]`
+### `"extraClassAttributes": ["hover-class", "placeholder-class"]`
 
-<eslint-code-block :rules="{'vue-scoped-css/no-unused-selector': ['error', {customClassAttributes: ['hover-class', 'placeholder-class']}]}">
+<eslint-code-block :rules="{'vue-scoped-css/no-unused-selector': ['error', {extraClassAttributes: ['hover-class', 'placeholder-class']}]}">
 
 ```vue
 <template>
   <div>
     <!-- These attributes will be checked for class names -->
-    <button hover-class="button-hover" placeholder-class="button-placeholder">Button</button>
-    <input
-      :hover-class="dynamicHoverClass"
-      :placeholder-class="['input-placeholder', 'input-focus']"
-    />
+    <button class="button" hover-class="button-hover">Button</button>
+    <input placeholder-class="input-placeholder" >
   </div>
 </template>
 <style scoped>
 /* ✓ GOOD - These selectors are used in custom attributes */
+.button {}
 .button-hover {}
-.button-placeholder {}
 .input-placeholder {}
-.input-focus {}
 
 /* ✗ BAD - This selector is not used anywhere */
 .unused-class {}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -3,13 +3,13 @@ import { toRegExp } from "./utils/regexp";
 export interface QueryOptions {
   ignoreBEMModifier?: boolean;
   captureClassesFromDoc?: string[];
-  customClassAttributes?: string[];
+  extraClassAttributes?: string[];
 }
 
 export interface ParsedQueryOptions {
   ignoreBEMModifier: boolean;
   captureClassesFromDoc: RegExp[];
-  customClassAttributes: string[];
+  extraClassAttributes: string[];
 }
 
 /**
@@ -18,13 +18,13 @@ export interface ParsedQueryOptions {
 export function parseQueryOptions(
   options: QueryOptions | undefined,
 ): ParsedQueryOptions {
-  const { ignoreBEMModifier, captureClassesFromDoc, customClassAttributes } =
+  const { ignoreBEMModifier, captureClassesFromDoc, extraClassAttributes } =
     options || {};
 
   return {
     ignoreBEMModifier: ignoreBEMModifier ?? false,
     captureClassesFromDoc:
       captureClassesFromDoc?.map((s) => toRegExp(s, "g")) ?? [],
-    customClassAttributes: customClassAttributes ?? [],
+    extraClassAttributes: extraClassAttributes ?? [],
   };
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -3,11 +3,13 @@ import { toRegExp } from "./utils/regexp";
 export interface QueryOptions {
   ignoreBEMModifier?: boolean;
   captureClassesFromDoc?: string[];
+  customClassAttributes?: string[];
 }
 
 export interface ParsedQueryOptions {
   ignoreBEMModifier: boolean;
   captureClassesFromDoc: RegExp[];
+  customClassAttributes: string[];
 }
 
 /**
@@ -16,11 +18,13 @@ export interface ParsedQueryOptions {
 export function parseQueryOptions(
   options: QueryOptions | undefined,
 ): ParsedQueryOptions {
-  const { ignoreBEMModifier, captureClassesFromDoc } = options || {};
+  const { ignoreBEMModifier, captureClassesFromDoc, customClassAttributes } =
+    options || {};
 
   return {
     ignoreBEMModifier: ignoreBEMModifier ?? false,
     captureClassesFromDoc:
       captureClassesFromDoc?.map((s) => toRegExp(s, "g")) ?? [],
+    customClassAttributes: customClassAttributes ?? [],
   };
 }

--- a/lib/rules/no-unused-selector.ts
+++ b/lib/rules/no-unused-selector.ts
@@ -123,7 +123,7 @@ export = {
           checkUnscoped: {
             type: "boolean",
           },
-          customClassAttributes: {
+          extraClassAttributes: {
             type: "array",
             items: {
               type: "string",

--- a/lib/rules/no-unused-selector.ts
+++ b/lib/rules/no-unused-selector.ts
@@ -123,6 +123,14 @@ export = {
           checkUnscoped: {
             type: "boolean",
           },
+          customClassAttributes: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            minItems: 0,
+            uniqueItems: true,
+          },
         },
         additionalProperties: false,
       },

--- a/lib/styles/selectors/query/attribute-tracker.ts
+++ b/lib/styles/selectors/query/attribute-tracker.ts
@@ -16,6 +16,7 @@ export function getAttributeValueNodes(
   context: RuleContext,
 ): AttributeValueExpressions[] | null {
   const results: AttributeValueExpressions[] = [];
+  const lowedName = name.toLowerCase();
   const { startTag } = element;
   for (const attr of startTag.attributes) {
     if (!isVDirective(attr)) {
@@ -23,7 +24,7 @@ export function getAttributeValueNodes(
       if (value == null) {
         continue;
       }
-      if (key.name === name) {
+      if (key.name === lowedName) {
         results.push(value);
       }
     } else {
@@ -39,7 +40,7 @@ export function getAttributeValueNodes(
         // bind name is unknown.
         return null;
       }
-      if (bindArg !== name) {
+      if (bindArg !== lowedName) {
         continue;
       }
       const { expression } = value;

--- a/lib/styles/selectors/query/index.ts
+++ b/lib/styles/selectors/query/index.ts
@@ -762,16 +762,15 @@ function matchClassName(
       return true;
     }
   }
-  const nodes = getAttributeValueNodes(element, "class", document.context);
-  if (nodes == null) {
+
+  // Check class attribute
+  if (matchClassNameForAttribute(element, "class", className, document)) {
     return true;
   }
-  for (const node of nodes) {
-    if (node.type === "VLiteral") {
-      if (includesClassName(node.value, className)) {
-        return true;
-      }
-    } else if (matchClassNameExpression(node, className, document)) {
+
+  // Check custom class attributes
+  for (const attrName of document.options.customClassAttributes) {
+    if (matchClassNameForAttribute(element, attrName, className, document)) {
       return true;
     }
   }
@@ -790,6 +789,31 @@ function matchClassName(
     return true;
   }
 
+  return false;
+}
+
+/**
+ * Checks whether the given element matches the given class name for a specific attribute.
+ */
+function matchClassNameForAttribute(
+  element: AST.VElement,
+  attrName: string,
+  className: Template,
+  document: VueDocumentQueryContext,
+): boolean {
+  const nodes = getAttributeValueNodes(element, attrName, document.context);
+  if (nodes == null) {
+    return true;
+  }
+  for (const node of nodes) {
+    if (node.type === "VLiteral") {
+      if (includesClassName(node.value, className)) {
+        return true;
+      }
+    } else if (matchClassNameExpression(node, className, document)) {
+      return true;
+    }
+  }
   return false;
 }
 

--- a/lib/styles/selectors/query/index.ts
+++ b/lib/styles/selectors/query/index.ts
@@ -1,3 +1,4 @@
+import lodash from "lodash";
 import {
   isTypeSelector,
   isIDSelector,
@@ -763,13 +764,11 @@ function matchClassName(
     }
   }
 
-  // Check class attribute
-  if (matchClassNameForAttribute(element, "class", className, document)) {
-    return true;
-  }
-
-  // Check custom class attributes
-  for (const attrName of document.options.customClassAttributes) {
+  const uniquedAttrs = lodash.uniq([
+    "class",
+    ...document.options.extraClassAttributes,
+  ]);
+  for (const attrName of uniquedAttrs) {
     if (matchClassNameForAttribute(element, attrName, className, document)) {
       return true;
     }

--- a/tests/lib/rules/no-unused-selector.ts
+++ b/tests/lib/rules/no-unused-selector.ts
@@ -326,7 +326,7 @@ tester.run("no-unused-selector", rule as any, {
             </template>
             <style scoped lang="scss">
             /* ✓ GOOD */
-            
+
             // A button suitable for giving a star to someone.
             //
             // :hover             - Subtle hover highlight.
@@ -473,6 +473,110 @@ tester.run("no-unused-selector", rule as any, {
         }
         </style>
         `,
+    // customClassAttributes option
+    {
+      code: `
+        <template>
+            <div hover-class="foo"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        </style>
+        `,
+      options: [{ customClassAttributes: ["hover-class"] }],
+    },
+    {
+      code: `
+        <template>
+            <div :hover-class="dynamicClass"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        </style>
+        <script>
+        export default {
+            data () {
+                return {
+                    dynamicClass: 'foo'
+                }
+            }
+        }
+        </script>
+        `,
+      options: [{ customClassAttributes: ["hover-class"] }],
+    },
+    {
+      code: `
+        <template>
+            <div hover-class="foo" placeholder-class="bar"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        .bar {}
+        </style>
+        `,
+      options: [
+        { customClassAttributes: ["hover-class", "placeholder-class"] },
+      ],
+    },
+    {
+      code: `
+        <template>
+            <div :hover-class="['foo', 'bar']" :placeholder-class="{baz: true}"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        .bar {}
+        .baz {}
+        </style>
+        `,
+      options: [
+        { customClassAttributes: ["hover-class", "placeholder-class"] },
+      ],
+    },
+    {
+      code: `
+        <template>
+            <div data-class="foo"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        </style>
+        `,
+      options: [{ customClassAttributes: ["data-class"] }],
+    },
+    {
+      code: `
+        <template>
+            <div v-bind:data-class="dynamicClass"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        </style>
+        <script>
+        export default {
+            data () {
+                return {
+                    dynamicClass: 'foo'
+                }
+            }
+        }
+        </script>
+        `,
+      options: [{ customClassAttributes: ["data-class"] }],
+    },
+    {
+      code: `
+        <template>
+            <div class="foo" hover-class="bar"></div>
+        </template>
+        <style scoped>
+        .foo {}
+        .bar {}
+        </style>
+        `,
+      options: [{ customClassAttributes: ["hover-class"] }],
+    },
   ],
   invalid: [
     {
@@ -756,7 +860,7 @@ tester.run("no-unused-selector", rule as any, {
             </template>
             <style scoped lang="scss">
             /* ✓ GOOD */
-            
+
             // A button suitable for giving a star to someone.
             //
             // :hover             - Subtle hover highlight.

--- a/tests/lib/rules/no-unused-selector.ts
+++ b/tests/lib/rules/no-unused-selector.ts
@@ -473,7 +473,7 @@ tester.run("no-unused-selector", rule as any, {
         }
         </style>
         `,
-    // customClassAttributes option
+    // extraClassAttributes option
     {
       code: `
         <template>
@@ -483,7 +483,7 @@ tester.run("no-unused-selector", rule as any, {
         .foo {}
         </style>
         `,
-      options: [{ customClassAttributes: ["hover-class"] }],
+      options: [{ extraClassAttributes: ["hover-class"] }],
     },
     {
       code: `
@@ -503,7 +503,7 @@ tester.run("no-unused-selector", rule as any, {
         }
         </script>
         `,
-      options: [{ customClassAttributes: ["hover-class"] }],
+      options: [{ extraClassAttributes: ["hover-class"] }],
     },
     {
       code: `
@@ -515,9 +515,7 @@ tester.run("no-unused-selector", rule as any, {
         .bar {}
         </style>
         `,
-      options: [
-        { customClassAttributes: ["hover-class", "placeholder-class"] },
-      ],
+      options: [{ extraClassAttributes: ["hover-class", "placeholder-class"] }],
     },
     {
       code: `
@@ -530,9 +528,7 @@ tester.run("no-unused-selector", rule as any, {
         .baz {}
         </style>
         `,
-      options: [
-        { customClassAttributes: ["hover-class", "placeholder-class"] },
-      ],
+      options: [{ extraClassAttributes: ["hover-class", "placeholder-class"] }],
     },
     {
       code: `
@@ -543,7 +539,7 @@ tester.run("no-unused-selector", rule as any, {
         .foo {}
         </style>
         `,
-      options: [{ customClassAttributes: ["data-class"] }],
+      options: [{ extraClassAttributes: ["data-class"] }],
     },
     {
       code: `
@@ -563,7 +559,7 @@ tester.run("no-unused-selector", rule as any, {
         }
         </script>
         `,
-      options: [{ customClassAttributes: ["data-class"] }],
+      options: [{ extraClassAttributes: ["data-class"] }],
     },
     {
       code: `
@@ -575,7 +571,7 @@ tester.run("no-unused-selector", rule as any, {
         .bar {}
         </style>
         `,
-      options: [{ customClassAttributes: ["hover-class"] }],
+      options: [{ extraClassAttributes: ["hover-class"] }],
     },
   ],
   invalid: [


### PR DESCRIPTION
## Summary
This PR adds a new configuration option to the `vue-scoped-css/no-unused-selector` rule that allows matching "class-like" attributes in addition to the standard `class`. This is useful for ecosystems derived from the Web, such as MiniApp platforms, where non-standard attributes like `hover-class` are commonly used. Frameworks like [DCloud's](https://www.dcloud.io/) uni-app make it possible to write Vue once and target multiple platforms (MiniApp, Web, Native), hence the need for this option.

## Motivation
[MiniApps](https://developers.weixin.qq.com/miniprogram/en/dev/framework/) (a Web-derived application form popular in China) diverge from the standard Web in certain template attributes. For example, they support attributes such as `hover-class`. On top of these ecosystems, frameworks like DCloud’s uni-app help developers write cross-platform apps using Vue syntax for MiniApp, standard Web, and Native. To better support such Web-derived ecosystems, this rule should be able to treat specific non-standard attributes as class-like when checking unused selectors.

## Changes
- Add new option: `extraClassAttributes: string[]`
  - Purpose: Specify attribute names (besides `class`) that should be treated as class-like and included in matching (e.g., `hover-class`, `hoverClass`, `placeholder-class`).
  - Default: `[]` (no behavior change unless configured)
  - Semantics: `class` is always checked; this option adds “extra” attributes to check in addition.
- Documentation
  - Update `docs/rules/no-unused-selector.md` to document the option and provide usage examples.
- Tests
  - Add valid and invalid cases for `extraClassAttributes`, covering static, dynamic, array, and object binding syntaxes.

## Usage
Flat config:
```js
import eslintPluginVueScopedCSS from 'eslint-plugin-vue-scoped-css'

export default [
  ...eslintPluginVueScopedCSS.configs['flat/recommended'],
  {
    rules: {
      'vue-scoped-css/no-unused-selector': ['error', {
        extraClassAttributes: ['hover-class'],
      }],
    },
  },
]
```

Legacy config:
```js
module.exports = {
  parser: 'vue-eslint-parser',
  extends: ['plugin:vue-scoped-css/vue3-recommended'],
  rules: {
    'vue-scoped-css/no-unused-selector': ['error', {
      extraClassAttributes: ['hover-class'],
    }],
  },
}
```

Template example (e.g., MiniApp/uni-app):
```vue
<template>
  <view
    class="btn"
    :hover-class="disabled ? '' : 'btn-hover'"
  />
</template>

<style scoped>
.btn {}

.btn-hover {}
</style>
```

## Impact
- No change when the option is not configured.
- Projects targeting MiniApp / uni-app and similar platforms can avoid false positives (e.g., `.btn-hover` combined with `:hover-class`) in `no-unused-selector`.