### PR TITLE
refactor: replace lodash with es-toolkit and vanilla js

### DIFF
--- a/.changeset/plenty-dragons-sneeze.md
+++ b/.changeset/plenty-dragons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue-scoped-css": minor
+---
+
+refactor: replace lodash with es-toolkit and vanilla js

--- a/lib/rules/enforce-style-type.ts
+++ b/lib/rules/enforce-style-type.ts
@@ -1,4 +1,3 @@
-import lodash from "lodash";
 import type {
   RuleContext,
   AST,
@@ -200,7 +199,7 @@ export default {
                         .join(", "),
                     },
                     fix(fixer: RuleFixer) {
-                      return lodash.flatMap(forbiddenAttrs, (attr) =>
+                      return forbiddenAttrs.flatMap((attr) =>
                         removeAttr(fixer, attr),
                       );
                     },

--- a/lib/styles/parser/selector/replace-utils.ts
+++ b/lib/styles/parser/selector/replace-utils.ts
@@ -1,4 +1,8 @@
-import lodash from "lodash";
+import {
+  get as getPath,
+  set as setPath,
+  sortedLastIndex,
+} from "es-toolkit/compat";
 import type { LineAndColumnData, PostCSSSPNode } from "../../../types.ts";
 import { isPostCSSSPContainer } from "../utils.ts";
 
@@ -36,7 +40,7 @@ class SourceCodeLocationResolver {
         column: index - lineStartIndices[lineStartIndices.length - 1],
       };
     }
-    const lineNumber = lodash.sortedLastIndex(lineStartIndices, index);
+    const lineNumber = sortedLastIndex(lineStartIndices, index);
 
     return {
       line: lineNumber,
@@ -546,12 +550,12 @@ function restoreReplaceNodeProp(
   prop: string,
   replaceInfo: ReplaceInfo,
 ): boolean {
-  const text = `${lodash.get(node, prop, "") || ""}`;
+  const text = `${getPath(node, prop, "") || ""}`;
   if (text.includes(replaceInfo.replace)) {
     const newText = text.replace(replaceInfo.replace, replaceInfo.original);
-    lodash.set(node, prop, newText);
+    setPath(node, prop, newText);
     if (!prop.startsWith("raws")) {
-      lodash.set(node, `raws.${prop}`, newText);
+      setPath(node, `raws.${prop}`, newText);
     }
     return true;
   }

--- a/lib/styles/selectors/query/index.ts
+++ b/lib/styles/selectors/query/index.ts
@@ -1,4 +1,3 @@
-import lodash from "lodash";
 import {
   isTypeSelector,
   isIDSelector,
@@ -766,10 +765,9 @@ function matchClassName(
     }
   }
 
-  const uniquedAttrs = lodash.uniq([
-    "class",
-    ...document.options.extraClassAttributes,
-  ]);
+  const uniquedAttrs = [
+    ...new Set(["class", ...document.options.extraClassAttributes]),
+  ];
   for (const attrName of uniquedAttrs) {
     if (matchClassNameForAttribute(element, attrName, className, document)) {
       return true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "lodash": "^4.17.21",
+        "es-toolkit": "^1.46.1",
         "postcss": "^8.4.31",
         "postcss-safe-parser": "^7.0.0",
         "postcss-selector-parser": "^7.0.0"
@@ -23,7 +23,6 @@
         "@oxc-node/core": "^0.1.0",
         "@svitejs/changesets-changelog-github-compact": "^1.1.0",
         "@types/estree": "^1.0.5",
-        "@types/lodash": "^4.17.5",
         "@types/mocha": "^10.0.7",
         "@types/node": "^24.0.0",
         "@types/semver": "^7.5.8",
@@ -3346,12 +3345,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
-      "dev": true
-    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
@@ -5059,6 +5052,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -7337,7 +7340,8 @@
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
     },
     "node_modules/lodash.sortedlastindex": {
       "version": "4.1.0",
@@ -14930,12 +14934,6 @@
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
-      "dev": true
-    },
     "@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
@@ -16099,6 +16097,11 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
+    },
+    "es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="
     },
     "esbuild": {
       "version": "0.28.0",
@@ -17647,7 +17650,8 @@
     "lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
     },
     "lodash.sortedlastindex": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@oxc-node/core": "^0.1.0",
     "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@types/estree": "^1.0.5",
-    "@types/lodash": "^4.17.5",
     "@types/mocha": "^10.0.7",
     "@types/node": "^24.0.0",
     "@types/semver": "^7.5.8",
@@ -114,7 +113,7 @@
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.4.0",
-    "lodash": "^4.17.21",
+    "es-toolkit": "^1.46.1",
     "postcss": "^8.4.31",
     "postcss-safe-parser": "^7.0.0",
     "postcss-selector-parser": "^7.0.0"


### PR DESCRIPTION
This PR replaces `lodash` dependency with a modern `es-toolkit` alternative, and in some cases with vanilla replacements.