### PR TITLE
fix: type recommended configs for defineConfig

### DIFF
--- a/.changeset/sour-needles-cover.md
+++ b/.changeset/sour-needles-cover.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue-scoped-css": patch
+---
+
+Improved type definitions for compatibility with `defineConfig`

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,11 +1,23 @@
 import { rules as ruleList } from "./utils/rules.ts";
 import type { Rule } from "./types.ts";
+import type { Linter } from "eslint";
 import flatBase from "./configs/flat/base.ts";
 import flatRecommended from "./configs/flat/recommended.ts";
 import flatVue2Recommended from "./configs/flat/vue2-recommended.ts";
 import flatAll from "./configs/flat/all.ts";
 
-const configs = {
+type Configs = {
+  base: Linter.Config[];
+  recommended: Linter.Config[];
+  "vue2-recommended": Linter.Config[];
+  all: Linter.Config[];
+  "flat/base": Linter.Config[];
+  "flat/recommended": Linter.Config[];
+  "flat/vue2-recommended": Linter.Config[];
+  "flat/all": Linter.Config[];
+};
+
+const configs: Configs = {
   base: flatBase,
   recommended: flatRecommended,
   "vue2-recommended": flatVue2Recommended,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,7 @@ import type { AST } from "vue-eslint-parser";
 import type * as postcss from "postcss";
 import type selectorParser from "postcss-selector-parser";
 import type { ScopeManager } from "eslint-scope";
-import type { Rule } from "eslint";
+import type { Linter, Rule } from "eslint";
 
 export { AST };
 
@@ -19,7 +19,7 @@ export type Rule = {
       categories: ("vue2-recommended" | "vue3-recommended")[];
       ruleId?: string;
       ruleName?: string;
-      default?: string;
+      default?: Linter.RuleSeverity;
       replacedBy?: string[];
       url: string;
       suggestion?: true;

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "../types.ts";
+import type { Linter } from "eslint";
 import enforceStyleType from "../rules/enforce-style-type.ts";
 import noDeprecatedDeepCombinator from "../rules/no-deprecated-deep-combinator.ts";
 import noDeprecatedVEnterVLeaveClass from "../rules/no-deprecated-v-enter-v-leave-class.ts";
@@ -111,17 +112,14 @@ export const rules = baseRules.map((obj) => {
  */
 export function collectRules(
   category?: "vue2-recommended" | "vue3-recommended",
-): { [key: string]: string } {
-  return rules.reduce(
-    (obj, rule) => {
-      if (
-        (!category || rule.meta.docs.categories.includes(category)) &&
-        !rule.meta.deprecated
-      ) {
-        obj[rule.meta.docs.ruleId || ""] = rule.meta.docs.default || "error";
-      }
-      return obj;
-    },
-    {} as { [key: string]: string },
-  );
+): Linter.RulesRecord {
+  return rules.reduce<Linter.RulesRecord>((obj, rule) => {
+    if (
+      (!category || rule.meta.docs.categories.includes(category)) &&
+      !rule.meta.deprecated
+    ) {
+      obj[rule.meta.docs.ruleId || ""] = rule.meta.docs.default || "error";
+    }
+    return obj;
+  }, {});
 }

--- a/tests/lib/configs/recommended.ts
+++ b/tests/lib/configs/recommended.ts
@@ -1,13 +1,17 @@
 import assert from "node:assert";
 import plugin from "../../../lib/index.ts";
+import { defineConfig } from "eslint/config";
 import { ESLint } from "eslint";
 
 const code = `<template><div class="foo"/></template> <script> ; </script> <style> bar {} </style>`;
 describe("`recommended` config", () => {
+  it("is compatible with `defineConfig`", () => {
+    void defineConfig(...plugin.configs.recommended);
+  });
+
   it("`recommended` config should work. ", async () => {
     const linter = new ESLint({
       overrideConfigFile: true,
-      // @ts-expect-error -- typing bug
       overrideConfig: [...plugin.configs.recommended],
     });
     const result = await linter.lintText(code, { filePath: "test.vue" });
@@ -31,7 +35,6 @@ describe("`recommended` config", () => {
   it("`recommended` config with *.js should work. ", async () => {
     const linter = new ESLint({
       overrideConfigFile: true,
-      // @ts-expect-error -- typing bug
       overrideConfig: [...plugin.configs.recommended],
     });
 
@@ -50,7 +53,6 @@ describe("`recommended` config", () => {
   it("`flat/recommended` backward-compat alias should work. ", async () => {
     const linter = new ESLint({
       overrideConfigFile: true,
-      // @ts-expect-error -- typing bug
       overrideConfig: [...plugin.configs["flat/recommended"]],
     });
     const result = await linter.lintText(code, { filePath: "test.vue" });


### PR DESCRIPTION
## Summary

- Type exported plugin configs with ESLint public config types.
- Preserve rule documentation severity as the accepted ESLint severity type.
- Add a regression test covering defineConfig spread of plugin.configs.recommended.

Fixes #471

## Validation

- npm run typecheck
- Full test suite: 847 passing
- Targeted lint and formatting checks
- git diff --check

Assisted-by: OpenAI Codex. AI assistance was used for investigation, implementation, and test drafting; the submitted diff was reviewed and validated before publication.