### PR TITLE
fix: keep generated rule types in sync

### DIFF
--- a/.changeset/strong-eggs-judge.md
+++ b/.changeset/strong-eggs-judge.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue-scoped-css": patch
+---
+
+Fixed generated rule configurations to retain ESLint-compatible types.

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -18,7 +18,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
       - name: Install Packages
-        run: npm install
+        run: npm ci
+      - name: Check Generated Files
+        run: |
+          npm run update
+          git diff --exit-code
+          git status --short
+          test -z "$(git status --porcelain)"
       - name: Build
         run: npm run build
       - name: Lint

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -19,14 +19,14 @@ jobs:
       - uses: actions/setup-node@v7
       - name: Install Packages
         run: npm ci
+      - name: Build
+        run: npm run build
       - name: Check Generated Files
         run: |
           npm run update
           git diff --exit-code
           git status --short
           test -z "$(git status --porcelain)"
-      - name: Build
-        run: npm run build
       - name: Lint
         run: npm run lint
   test:

--- a/lib/utils/rules.ts
+++ b/lib/utils/rules.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "../types.ts";
+import type { Linter } from "eslint";
 import enforceStyleType from "../rules/enforce-style-type.ts";
 import noDeprecatedDeepCombinator from "../rules/no-deprecated-deep-combinator.ts";
 import noDeprecatedVEnterVLeaveClass from "../rules/no-deprecated-v-enter-v-leave-class.ts";
@@ -111,17 +112,14 @@ export const rules = baseRules.map((obj) => {
  */
 export function collectRules(
   category?: "vue2-recommended" | "vue3-recommended",
-): { [key: string]: string } {
-  return rules.reduce(
-    (obj, rule) => {
-      if (
-        (!category || rule.meta.docs.categories.includes(category)) &&
-        !rule.meta.deprecated
-      ) {
-        obj[rule.meta.docs.ruleId || ""] = rule.meta.docs.default || "error";
-      }
-      return obj;
-    },
-    {} as { [key: string]: string },
-  );
+): Linter.RulesRecord {
+  return rules.reduce<Linter.RulesRecord>((obj, rule) => {
+    if (
+      (!category || rule.meta.docs.categories.includes(category)) &&
+      !rule.meta.deprecated
+    ) {
+      obj[rule.meta.docs.ruleId || ""] = rule.meta.docs.default || "error";
+    }
+    return obj;
+  }, {});
 }

--- a/tools/lib/load-rules.ts
+++ b/tools/lib/load-rules.ts
@@ -15,7 +15,10 @@ function readRules() {
     path.dirname(fileURLToPath(import.meta.url)),
     "../../lib/rules",
   );
-  const result = fs.readdirSync(rulesLibRoot);
+  const result = fs
+    .readdirSync(rulesLibRoot)
+    .filter((name) => name.endsWith(".ts"))
+    .sort();
   const rules = [];
   for (const name of result) {
     const ruleName = name.replace(/\.ts$/u, "");

--- a/tools/update-rules.ts
+++ b/tools/update-rules.ts
@@ -15,6 +15,7 @@ function toCamelCase(name: string): string {
 
 let content = `
 import type { Rule } from "../types.ts";
+import type { Linter } from "eslint";
 ${rules
   .map(
     (rule) =>
@@ -55,8 +56,8 @@ export const rules = baseRules.map(obj => {
  */
 export function collectRules(
     category?: "vue2-recommended" | "vue3-recommended",
-): { [key: string]: string } {
-    return rules.reduce((obj, rule) => {
+): Linter.RulesRecord {
+    return rules.reduce<Linter.RulesRecord>((obj, rule) => {
         if (
             (!category || rule.meta.docs.categories.includes(category)) &&
             !rule.meta.deprecated
@@ -64,7 +65,7 @@ export function collectRules(
             obj[rule.meta.docs.ruleId || ""] = rule.meta.docs.default || "error"
         }
         return obj
-    }, {} as { [key: string]: string })
+    }, {})
 }
 `;
 


### PR DESCRIPTION
The release workflow runs `npm run update`, but `tools/update-rules.ts` still emitted the pre-#513 `{ [key: string]: string }` type. Release PR #516 therefore regenerated `lib/utils/rules.ts`, reverted `Linter.RulesRecord`, and broke type checking on `master`.

Teach the generator to emit `Linter.RulesRecord` and make rule discovery deterministic. The lint job now installs from the lockfile and verifies that generation leaves no tracked or untracked changes, preventing generated source from drifting again. A patch changeset records the correction for the next release.
